### PR TITLE
CIテスト失敗とダークモードのバグを修正

### DIFF
--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -1,2 +1,3 @@
 //= link_tree ../images
 //= link_tree ../builds
+//= link application.css

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -2,3 +2,4 @@
 // Entry point for the build script in your package.json
 import "@hotwired/turbo-rails"
 import "./controllers"
+import "./dark_mode"

--- a/app/javascript/dark_mode.js
+++ b/app/javascript/dark_mode.js
@@ -1,0 +1,55 @@
+// ダークモード機能
+// ページ読み込み前にダークモードを設定（FOUC防止）
+function initializeDarkMode() {
+  const theme = localStorage.getItem('theme') || 'light';
+  if (theme === 'dark') {
+    document.documentElement.classList.add('dark');
+  } else {
+    document.documentElement.classList.remove('dark');
+  }
+}
+
+// ダークモード切り替えボタンのイベントリスナーを設定
+function setupDarkModeToggle() {
+  const darkModeToggle = document.getElementById('darkModeToggle');
+
+  if (darkModeToggle) {
+    // 既存のイベントリスナーを削除（重複登録を防ぐ）
+    const newToggle = darkModeToggle.cloneNode(true);
+    darkModeToggle.parentNode.replaceChild(newToggle, darkModeToggle);
+
+    newToggle.addEventListener('click', function() {
+      const html = document.documentElement;
+      const isDark = html.classList.contains('dark');
+
+      if (isDark) {
+        // ライトモードに切り替え
+        html.classList.remove('dark');
+        localStorage.setItem('theme', 'light');
+      } else {
+        // ダークモードに切り替え
+        html.classList.add('dark');
+        localStorage.setItem('theme', 'dark');
+      }
+    });
+  }
+}
+
+// 初期化処理（スクリプト読み込み時に即座に実行）
+initializeDarkMode();
+
+// Turboのページロードイベントでダークモードを再初期化
+document.addEventListener('turbo:load', function() {
+  initializeDarkMode();
+  setupDarkModeToggle();
+});
+
+// 通常のDOMContentLoadedイベント（Turboが無効な場合のフォールバック）
+document.addEventListener('DOMContentLoaded', function() {
+  setupDarkModeToggle();
+});
+
+// Turbo遷移前にダークモードの状態を保持
+document.addEventListener('turbo:before-render', function() {
+  initializeDarkMode();
+});

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -29,29 +29,6 @@
       }
     })();
   </script>
-
-  <!-- ダークモードボタン用のカスタムスタイル -->
-  <style>
-    /* ライトモード時: 月アイコンとダークテキストを表示 */
-    .theme-icon-light,
-    .theme-text-light {
-      display: inline;
-    }
-    .theme-icon-dark,
-    .theme-text-dark {
-      display: none;
-    }
-
-    /* ダークモード時: 太陽アイコンとライトテキストを表示 */
-    .dark .theme-icon-light,
-    .dark .theme-text-light {
-      display: none;
-    }
-    .dark .theme-icon-dark,
-    .dark .theme-text-dark {
-      display: inline;
-    }
-  </style>
 </head>
 
 <body class="bg-background-light dark:bg-background-dark font-display transition-colors duration-200">
@@ -185,29 +162,5 @@
       </nav>
     <% end %>
   </div>
-
-  <!-- ダークモード切り替えスクリプト -->
-  <script>
-    document.addEventListener('DOMContentLoaded', function() {
-      const darkModeToggle = document.getElementById('darkModeToggle');
-
-      if (darkModeToggle) {
-        darkModeToggle.addEventListener('click', function() {
-          const html = document.documentElement;
-          const isDark = html.classList.contains('dark');
-
-          if (isDark) {
-            // ライトモードに切り替え
-            html.classList.remove('dark');
-            localStorage.setItem('theme', 'light');
-          } else {
-            // ダークモードに切り替え
-            html.classList.add('dark');
-            localStorage.setItem('theme', 'dark');
-          }
-        });
-      }
-    });
-  </script>
 </body>
 </html>

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -1,8 +1,6 @@
 threads_count = ENV.fetch("RAILS_MAX_THREADS", 3)
 threads threads_count, threads_count
 
-port ENV.fetch("PORT", 3000)
-
 environment ENV.fetch("RAILS_ENV") { "development" }
 
 # Bind to 0.0.0.0 to allow access from outside Docker container


### PR DESCRIPTION
【修正内容】
1. CIテストエラー修正
   - application.cssをmanifest.jsのプリコンパイルリストに追加
   - 「Asset application.css was not declared to be precompiled」エラーを解消

2. ダークモード機能の改善
   - ページ遷移時にスーパーリロードが必要だったバグを修正
   - Turbo Rails対応のため、ダークモード機能を専用JSファイルに移行
   - turbo:load、turbo:before-renderイベントに対応

3. コードの最適化
   - レイアウトファイルから重複するCSSスタイルを削除
   - Pumaの冗長なポート設定を整理

【変更ファイル】
- app/assets/config/manifest.js: application.cssを追加
- app/javascript/dark_mode.js: 新規作成
- app/javascript/application.js: dark_mode.jsをインポート
- app/views/layouts/application.html.erb: 重複コードを削除
- config/puma.rb: ポート設定を整理