### PR TITLE
Google OAuth連携のTurbo対応エラーを修正

### DIFF
--- a/app/views/walks/_form.html.erb
+++ b/app/views/walks/_form.html.erb
@@ -49,15 +49,20 @@
       </p>
     <% else %>
       <!-- Google Fit未連携の場合 -->
-      <%= link_to user_google_oauth2_omniauth_authorize_path, method: :post,
-          class: "w-full bg-white dark:bg-gray-700 hover:bg-gray-50 dark:hover:bg-gray-600 text-gray-800 dark:text-gray-200 font-bold py-3 px-6 rounded-lg shadow-md transition-colors flex items-center justify-center space-x-2 border border-gray-300 dark:border-gray-600" do %>
-        <svg class="w-5 h-5" viewBox="0 0 24 24">
-          <path fill="#4285F4" d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"/>
-          <path fill="#34A853" d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"/>
-          <path fill="#FBBC05" d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"/>
-          <path fill="#EA4335" d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"/>
-        </svg>
-        <span>Googleアカウントで連携</span>
+      <%= button_to user_google_oauth2_omniauth_authorize_path,
+          method: :post,
+          data: { turbo: false },
+          class: "w-full bg-white dark:bg-gray-700 hover:bg-gray-50 dark:hover:bg-gray-600 text-gray-800 dark:text-gray-200 font-bold py-3 px-6 rounded-lg shadow-md transition-colors border border-gray-300 dark:border-gray-600",
+          form_class: "w-full" do %>
+        <div class="flex items-center justify-center space-x-2">
+          <svg class="w-5 h-5" viewBox="0 0 24 24">
+            <path fill="#4285F4" d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"/>
+            <path fill="#34A853" d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"/>
+            <path fill="#FBBC05" d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"/>
+            <path fill="#EA4335" d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"/>
+          </svg>
+          <span>Googleアカウントで連携</span>
+        </div>
       <% end %>
       <p class="text-xs text-gray-600 dark:text-gray-400 mt-2">
         Google Fitと連携すると、歩数や距離などのデータを自動で取得できます

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -1,0 +1,8 @@
+# OmniAuthの初期化設定
+# omniauth-rails_csrf_protection gemを使用してCSRF保護を有効化
+
+# Rails 7のTurboとOmniAuthを連携させるための設定
+OmniAuth.config.allowed_request_methods = [ :post ]
+
+# テスト・開発環境でのSSL警告を無効化（本番環境では有効のまま）
+OmniAuth.config.silence_get_warning = true unless Rails.env.production?


### PR DESCRIPTION
- link_toをbutton_toに変更してOmniAuthのPOSTリクエストを正しく処理
- data: { turbo: false }を追加してTurboをバイパス
- OmniAuthの初期化ファイルを追加し、CSRF保護を正しく設定
- "Not found. Authentication passthru."エラーを解決