### PR TITLE
散歩記録フォームの送信ボタンを修正

### DIFF
--- a/app/views/walks/_form.html.erb
+++ b/app/views/walks/_form.html.erb
@@ -13,7 +13,7 @@
 <% end %>
 
 <!-- 散歩記録フォーム -->
-<%= form_with(model: walk, local: true, class: "space-y-6") do |form| %>
+<%= form_with(model: walk, class: "space-y-6", data: { turbo: false }) do |form| %>
 
   <!-- 散歩日 -->
   <div>
@@ -119,7 +119,7 @@
   <!-- ボタン -->
   <div class="flex flex-col sm:flex-row gap-3 pt-4">
     <!-- 保存ボタン -->
-    <%= form.submit class: "flex-1 bg-sky-500 dark:bg-sky-600 hover:bg-sky-600 dark:hover:bg-sky-700 text-white font-bold py-3 px-6 rounded-lg shadow-md transition-colors cursor-pointer" %>
+    <%= form.submit "散歩記録を保存", class: "flex-1 bg-sky-500 dark:bg-sky-600 hover:bg-sky-600 dark:hover:bg-sky-700 text-white font-bold py-3 px-6 rounded-lg shadow-md transition-colors cursor-pointer" %>
 
     <!-- キャンセルボタン -->
     <%= link_to "キャンセル", walks_path,


### PR DESCRIPTION
- form_withのlocal: trueをdata: { turbo: false }に変更
- Turboとの競合を解消してフォーム送信を正常化
- submitボタンに明示的な日本語ラベルを追加