### PR TITLE
散歩記録フォームの送信エラーを修正

### DIFF
--- a/app/controllers/walks_controller.rb
+++ b/app/controllers/walks_controller.rb
@@ -20,7 +20,8 @@ class WalksController < ApplicationController
   # 新規散歩記録作成ページ（GET /walks/new）
   def new
     # 新しい散歩記録のインスタンスを作成
-    @walk = Walk.new
+    # デフォルト値として今日の日付を設定
+    @walk = Walk.new(walked_on: Date.today)
   end
 
   # 散歩記録編集ページ（GET /walks/:id/edit）

--- a/app/views/walks/_form.html.erb
+++ b/app/views/walks/_form.html.erb
@@ -22,7 +22,6 @@
       <span class="material-symbols-outlined absolute left-3 top-1/2 -translate-y-1/2 text-gray-400 dark:text-gray-500">calendar_today</span>
       <%= form.date_field :walked_on,
           id: "walk_walked_on",
-          value: Date.today,
           class: "w-full pl-10 pr-4 py-3 border border-gray-300 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-sky-500 focus:border-transparent bg-white dark:bg-gray-700 text-gray-900 dark:text-white transition-colors" %>
     </div>
   </div>


### PR DESCRIPTION
問題:
- フォームの日付フィールドに「value: Date.today」を直接指定していたため、 Railsのフォームヘルパーが正しく動作せず、編集時にも常に今日の日付で上書きされていた
- 新規作成時にデフォルト値が設定されていなかった

修正内容:
- フォームから「value: Date.today」を削除してRailsのフォームヘルパーの通常動作に戻す
- コントローラーのnewアクションでデフォルト値として今日の日付を設定
- これにより新規作成時は今日の日付がデフォルトで設定され、編集時は既存の日付が正しく表示される