### PR TITLE
FABの位置をメインコンテンツの幅に合わせて修正

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -123,61 +123,65 @@
           class="hidden fixed inset-0 bg-black opacity-0 transition-opacity duration-200 z-30">
         </div>
 
-        <!-- FABボタンコンテナ -->
-        <div class="fixed bottom-24 right-4 z-40">
-        <!-- アクションボタン（展開時に表示されるボタン群） -->
-        <!-- プライバシー -->
-        <%= link_to "#",
-            data: { expandable_fab_target: "actionButton" },
-            class: "hidden opacity-0 absolute bottom-72 right-0 flex items-center space-x-3 transition-all duration-200 transform translate-y-5",
-            style: "transform: translateY(20px);" do %>
-          <span class="bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-200 px-3 py-2 rounded-lg shadow-md text-sm font-medium whitespace-nowrap">プライバシー</span>
-          <div class="bg-blue-500 dark:bg-blue-600 text-white w-12 h-12 rounded-full flex items-center justify-center shadow-lg hover:bg-blue-600 dark:hover:bg-blue-700 transition-colors">
-            <span class="material-symbols-outlined text-2xl">privacy_tip</span>
-          </div>
-        <% end %>
+        <!-- FABボタンコンテナ（メインコンテンツの幅に合わせて配置） -->
+        <div class="fixed bottom-24 left-0 right-0 z-40 pointer-events-none">
+          <div class="max-w-4xl mx-auto px-4 relative h-0">
+            <div class="absolute bottom-0 right-0 pointer-events-auto">
+              <!-- アクションボタン（展開時に表示されるボタン群） -->
+              <!-- プライバシー -->
+              <%= link_to "#",
+                  data: { expandable_fab_target: "actionButton" },
+                  class: "hidden opacity-0 absolute bottom-72 right-0 flex items-center space-x-3 transition-all duration-200 transform translate-y-5",
+                  style: "transform: translateY(20px);" do %>
+                <span class="bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-200 px-3 py-2 rounded-lg shadow-md text-sm font-medium whitespace-nowrap">プライバシー</span>
+                <div class="bg-blue-500 dark:bg-blue-600 text-white w-12 h-12 rounded-full flex items-center justify-center shadow-lg hover:bg-blue-600 dark:hover:bg-blue-700 transition-colors">
+                  <span class="material-symbols-outlined text-2xl">privacy_tip</span>
+                </div>
+              <% end %>
 
-        <!-- 設定 -->
-        <%= link_to edit_user_registration_path,
-            data: { expandable_fab_target: "actionButton" },
-            class: "hidden opacity-0 absolute bottom-56 right-0 flex items-center space-x-3 transition-all duration-200 transform translate-y-5",
-            style: "transform: translateY(20px);" do %>
-          <span class="bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-200 px-3 py-2 rounded-lg shadow-md text-sm font-medium whitespace-nowrap">設定</span>
-          <div class="bg-gray-500 dark:bg-gray-600 text-white w-12 h-12 rounded-full flex items-center justify-center shadow-lg hover:bg-gray-600 dark:hover:bg-gray-700 transition-colors">
-            <span class="material-symbols-outlined text-2xl">settings</span>
-          </div>
-        <% end %>
+              <!-- 設定 -->
+              <%= link_to edit_user_registration_path,
+                  data: { expandable_fab_target: "actionButton" },
+                  class: "hidden opacity-0 absolute bottom-56 right-0 flex items-center space-x-3 transition-all duration-200 transform translate-y-5",
+                  style: "transform: translateY(20px);" do %>
+                <span class="bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-200 px-3 py-2 rounded-lg shadow-md text-sm font-medium whitespace-nowrap">設定</span>
+                <div class="bg-gray-500 dark:bg-gray-600 text-white w-12 h-12 rounded-full flex items-center justify-center shadow-lg hover:bg-gray-600 dark:hover:bg-gray-700 transition-colors">
+                  <span class="material-symbols-outlined text-2xl">settings</span>
+                </div>
+              <% end %>
 
-        <!-- ログインスタンプ -->
-        <%= link_to login_stamps_path,
-            data: { expandable_fab_target: "actionButton" },
-            class: "hidden opacity-0 absolute bottom-40 right-0 flex items-center space-x-3 transition-all duration-200 transform translate-y-5",
-            style: "transform: translateY(20px);" do %>
-          <span class="bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-200 px-3 py-2 rounded-lg shadow-md text-sm font-medium whitespace-nowrap">ログインスタンプ</span>
-          <div class="bg-purple-500 dark:bg-purple-600 text-white w-12 h-12 rounded-full flex items-center justify-center shadow-lg hover:bg-purple-600 dark:hover:bg-purple-700 transition-colors">
-            <span class="material-symbols-outlined text-2xl">calendar_month</span>
-          </div>
-        <% end %>
+              <!-- ログインスタンプ -->
+              <%= link_to login_stamps_path,
+                  data: { expandable_fab_target: "actionButton" },
+                  class: "hidden opacity-0 absolute bottom-40 right-0 flex items-center space-x-3 transition-all duration-200 transform translate-y-5",
+                  style: "transform: translateY(20px);" do %>
+                <span class="bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-200 px-3 py-2 rounded-lg shadow-md text-sm font-medium whitespace-nowrap">ログインスタンプ</span>
+                <div class="bg-purple-500 dark:bg-purple-600 text-white w-12 h-12 rounded-full flex items-center justify-center shadow-lg hover:bg-purple-600 dark:hover:bg-purple-700 transition-colors">
+                  <span class="material-symbols-outlined text-2xl">calendar_month</span>
+                </div>
+              <% end %>
 
-        <!-- 新しい散歩記録 -->
-        <%= link_to new_walk_path,
-            data: { expandable_fab_target: "actionButton" },
-            class: "hidden opacity-0 absolute bottom-24 right-0 flex items-center space-x-3 transition-all duration-200 transform translate-y-5",
-            style: "transform: translateY(20px);" do %>
-          <span class="bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-200 px-3 py-2 rounded-lg shadow-md text-sm font-medium whitespace-nowrap">新しい散歩記録</span>
-          <div class="bg-green-500 dark:bg-green-600 text-white w-12 h-12 rounded-full flex items-center justify-center shadow-lg hover:bg-green-600 dark:hover:bg-green-700 transition-colors">
-            <span class="material-symbols-outlined text-2xl">add_circle</span>
-          </div>
-        <% end %>
+              <!-- 新しい散歩記録 -->
+              <%= link_to new_walk_path,
+                  data: { expandable_fab_target: "actionButton" },
+                  class: "hidden opacity-0 absolute bottom-24 right-0 flex items-center space-x-3 transition-all duration-200 transform translate-y-5",
+                  style: "transform: translateY(20px);" do %>
+                <span class="bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-200 px-3 py-2 rounded-lg shadow-md text-sm font-medium whitespace-nowrap">新しい散歩記録</span>
+                <div class="bg-green-500 dark:bg-green-600 text-white w-12 h-12 rounded-full flex items-center justify-center shadow-lg hover:bg-green-600 dark:hover:bg-green-700 transition-colors">
+                  <span class="material-symbols-outlined text-2xl">add_circle</span>
+                </div>
+              <% end %>
 
-          <!-- メインFABボタン -->
-          <button
-            type="button"
-            data-expandable-fab-target="mainButton"
-            data-action="click->expandable-fab#toggle"
-            class="bg-sky-500 dark:bg-sky-600 text-white w-14 h-14 rounded-full flex items-center justify-center shadow-lg hover:bg-sky-600 dark:hover:bg-sky-700 transition-all duration-300">
-            <span class="material-symbols-outlined text-3xl">add</span>
-          </button>
+              <!-- メインFABボタン -->
+              <button
+                type="button"
+                data-expandable-fab-target="mainButton"
+                data-action="click->expandable-fab#toggle"
+                class="bg-sky-500 dark:bg-sky-600 text-white w-14 h-14 rounded-full flex items-center justify-center shadow-lg hover:bg-sky-600 dark:hover:bg-sky-700 transition-all duration-300">
+                <span class="material-symbols-outlined text-3xl">add</span>
+              </button>
+            </div>
+          </div>
         </div>
       </div>
 


### PR DESCRIPTION
PCブラウザで画面右端に表示されていた問題を解決しました。

修正内容：
- FABをメインコンテンツ（max-w-4xl）の幅に合わせて配置
- pointer-events-noneで背景領域のクリックを無効化
- pointer-events-autoでFABボタンのみクリック可能に
- レスポンシブデザインに対応

これでスマホでもPCでも、メインコンテンツの右端に
FABが正しく表示されるようになりました。