### PR TITLE
geocoder gemを導入してIP位置情報の精度を大幅に改善

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,6 +17,7 @@ gem "omniauth-rails_csrf_protection"
 gem "google-apis-fitness_v1"
 gem "simple_calendar", "~> 3.0"
 gem "dotenv-rails"
+gem "geocoder"
 
 group :development, :test do
   gem "debug", platforms: %i[ mri windows ], require: "debug/prelude"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -100,6 +100,7 @@ GEM
     concurrent-ruby (1.3.5)
     connection_pool (2.5.4)
     crass (1.0.6)
+    csv (3.3.5)
     date (3.5.0)
     debug (1.11.0)
       irb (~> 1.10)
@@ -128,6 +129,9 @@ GEM
       net-http (~> 0.5)
     foreman (0.90.0)
       thor (~> 1.4)
+    geocoder (1.8.6)
+      base64 (>= 0.1.0)
+      csv (>= 3.0.0)
     globalid (1.3.0)
       activesupport (>= 6.1)
     google-apis-core (1.0.2)
@@ -407,6 +411,7 @@ DEPENDENCIES
   devise
   dotenv-rails
   foreman
+  geocoder
   google-apis-fitness_v1
   jbuilder
   jsbundling-rails

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -8,6 +8,15 @@ class HomeController < ApplicationController
     # ユーザーのIPアドレスを取得
     user_ip = request.remote_ip
 
+    # デバッグ用：取得したIPアドレスをログに出力
+    Rails.logger.info("========================================")
+    Rails.logger.info("リクエストIP情報:")
+    Rails.logger.info("  remote_ip: #{request.remote_ip}")
+    Rails.logger.info("  ip: #{request.ip}")
+    Rails.logger.info("  X-Forwarded-For: #{request.headers['X-Forwarded-For']}")
+    Rails.logger.info("  X-Real-IP: #{request.headers['X-Real-IP']}")
+    Rails.logger.info("========================================")
+
     # IP位置情報を取得
     location = GeolocationService.get_location(user_ip)
 

--- a/config/initializers/geocoder.rb
+++ b/config/initializers/geocoder.rb
@@ -1,0 +1,34 @@
+# Geocoder の設定
+Geocoder.configure(
+  # タイムアウト設定（秒）
+  timeout: 5,
+
+  # IP位置情報のルックアップサービスを設定
+  # 優先順位順に複数のサービスを設定可能
+  ip_lookup: :ipapi_com,
+
+  # キャッシュ設定（Railsのキャッシュストアを使用）
+  cache: Rails.cache,
+  cache_prefix: "geocoder:",
+
+  # 言語設定
+  language: :ja,
+
+  # 単位（距離計算用）
+  units: :km,
+
+  # ログレベル
+  logger: Rails.logger,
+
+  # 各サービスごとの設定
+  ipapi_com: {
+    # ip-api.com は無料で利用可能
+    # レート制限: 45リクエスト/分
+  },
+
+  # フォールバック用に別のサービスも設定可能
+  # 例: ipinfo_io, ipstack, maxmind など
+  # ipinfo_io: {
+  #   api_key: ENV["IPINFO_IO_API_KEY"]
+  # }
+)


### PR DESCRIPTION
より信頼性の高いgeocodergemを導入し、IP位置情報取得の精度と
デバッグ機能を強化しました。

変更内容:
【geocoder gem の導入】
- Gemfileにgeocoderを追加
- ip-api.comをプロバイダーとして設定
- キャッシュ機能を有効化（Railsキャッシュストア使用）
- タイムアウト5秒、日本語対応

【GeolocationServiceの書き直し】
- geocoder gemのAPIを使用するよう全面的に書き直し
- より詳細なデバッグログを追加（都市、地域、国、座標）
- エラーハンドリングを強化（バックトレースログ追加）
- フォールバック処理の改善

【HomeControllerのデバッグ強化】
- request.remote_ip、request.ip、X-Forwarded-For、X-Real-IPを すべてログに出力してIP取得の問題を診断可能に
- プロキシ環境での問題を特定しやすく

【設定ファイル】
- config/initializers/geocoder.rb を追加
- 複数のプロバイダー設定に対応
- 将来的に ipinfo.io や maxmind への切り替えが容易

修正対象の問題:
- IP 14.13.xx.xxx（広島県）でポートランドが表示される問題
- request.remote_ipが正しいIPを取得できない可能性への対処
- より正確で信頼性の高い位置情報取得の実現