### PR TITLE
06 UI UX改善：ダークモード切り替えボタンの表示バグを修正

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -44,11 +44,13 @@
           aria-label="ダークモード切り替え"
           class="flex flex-col items-center justify-center text-gray-700 dark:text-gray-300 hover:text-primary dark:hover:text-sky-400 transition-colors p-2 rounded-lg">
           <!-- ライトモード時に表示：月のアイコンと「ダーク」テキスト -->
-          <span class="material-symbols-outlined text-2xl dark:hidden">dark_mode</span>
-          <span class="text-[8px] mt-0.5 font-medium dark:hidden">ダーク</span>
+          <!-- dark:!hidden = ダークモード時は必ず非表示にする（!で優先度を上げる） -->
+          <span class="material-symbols-outlined text-2xl dark:!hidden">dark_mode</span>
+          <span class="text-[8px] mt-0.5 font-medium dark:!hidden">ダーク</span>
           <!-- ダークモード時に表示：太陽のアイコンと「ライト」テキスト -->
-          <span class="material-symbols-outlined text-2xl hidden dark:block">light_mode</span>
-          <span class="text-[8px] mt-0.5 font-medium hidden dark:block">ライト</span>
+          <!-- !hidden = 最初は非表示、dark:!block = ダークモード時は必ず表示する（!で優先度を上げる） -->
+          <span class="material-symbols-outlined text-2xl !hidden dark:!block">light_mode</span>
+          <span class="text-[8px] mt-0.5 font-medium !hidden dark:!block">ライト</span>
         </button>
       </div>
 


### PR DESCRIPTION
ライトモード時に月と太陽のアイコンが同時に表示される問題を解決しました。

修正内容：
- CSSクラスにimportant修飾子（!）を追加して優先度を明示化
- ライトモード時：月のアイコン + 「ダーク」テキストのみ表示
- ダークモード時：太陽のアイコン + 「ライト」テキストのみ表示

原因：
hiddenクラスとdark:blockクラスの組み合わせでCSS詳細度が競合していたため、
!important修飾子を使って確実に表示/非表示を制御するようにしました。