### PR TITLE
ダークモード切り替えをiOS風トグルスイッチに変更

### DIFF
--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -2,5 +2,5 @@
 // Entry point for the build script in your package.json
 import "@hotwired/turbo-rails"
 import "./controllers"
-import "./dark_mode"
+// ダークモード機能はStimulusコントローラー（dark_mode_toggle_controller.js）で実装
 import "./google_fit"

--- a/app/javascript/controllers/dark_mode_toggle_controller.js
+++ b/app/javascript/controllers/dark_mode_toggle_controller.js
@@ -1,0 +1,99 @@
+import { Controller } from "@hotwired/stimulus"
+
+// =====================================
+// ダークモード切り替えトグルスイッチ
+// =====================================
+// iOS風のトグルスイッチでダークモードとライトモードを切り替えます
+// アニメーション付きで見た目も楽しいUIになっています
+
+export default class extends Controller {
+  // Stimulusが管理する要素（targets）を定義
+  static targets = ["toggle", "slider", "icon"]
+
+  // コントローラーが読み込まれた時に実行される
+  connect() {
+    // ページ読み込み時に、現在のテーマ設定を反映
+    this.updateUI()
+  }
+
+  // トグルスイッチがクリックされた時の処理
+  toggle() {
+    // 現在のテーマ状態を取得
+    const currentTheme = localStorage.getItem('theme') || 'light'
+
+    // テーマを切り替える
+    if (currentTheme === 'dark') {
+      // ダークモード → ライトモード
+      this.setLightMode()
+    } else {
+      // ライトモード → ダークモード
+      this.setDarkMode()
+    }
+  }
+
+  // ライトモードに設定
+  setLightMode() {
+    // htmlタグからdarkクラスを削除
+    document.documentElement.classList.remove('dark')
+    // localStorageに保存
+    localStorage.setItem('theme', 'light')
+    // UIを更新
+    this.updateUI()
+  }
+
+  // ダークモードに設定
+  setDarkMode() {
+    // htmlタグにdarkクラスを追加
+    document.documentElement.classList.add('dark')
+    // localStorageに保存
+    localStorage.setItem('theme', 'dark')
+    // UIを更新
+    this.updateUI()
+  }
+
+  // UIの表示を現在のテーマに合わせて更新
+  updateUI() {
+    // 現在のテーマ状態を取得
+    const currentTheme = localStorage.getItem('theme') || 'light'
+    const isDark = currentTheme === 'dark'
+
+    // トグルボタンの背景色を変更
+    if (isDark) {
+      // ダークモード時：青いグラデーション背景
+      this.toggleTarget.classList.remove('bg-gray-300')
+      this.toggleTarget.classList.add('bg-gradient-to-r', 'from-blue-500', 'to-sky-400')
+    } else {
+      // ライトモード時：グレー背景
+      this.toggleTarget.classList.remove('bg-gradient-to-r', 'from-blue-500', 'to-sky-400')
+      this.toggleTarget.classList.add('bg-gray-300')
+    }
+
+    // スライダー（丸いつまみ）の位置を変更
+    if (isDark) {
+      // ダークモード時：右側に移動
+      this.sliderTarget.style.transform = 'translateX(28px)'
+    } else {
+      // ライトモード時：左側に移動
+      this.sliderTarget.style.transform = 'translateX(0)'
+    }
+
+    // アイコンの表示/非表示を切り替え
+    this.iconTargets.forEach((icon) => {
+      const iconType = icon.dataset.icon
+
+      if (isDark && iconType === 'sun') {
+        // ダークモード時は太陽アイコンを表示
+        icon.classList.remove('opacity-0', 'scale-0')
+        icon.classList.add('opacity-100', 'scale-100')
+      } else if (!isDark && iconType === 'moon') {
+        // ライトモード時は月アイコンを表示
+        icon.classList.remove('opacity-0', 'scale-0')
+        icon.classList.add('opacity-100', 'scale-100')
+      } else {
+        // それ以外は非表示
+        icon.classList.remove('opacity-100', 'scale-100')
+        icon.classList.add('opacity-0', 'scale-0')
+      }
+    })
+  }
+}

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -4,6 +4,9 @@
 
 import { application } from "./application"
 
+import DarkModeToggleController from "./dark_mode_toggle_controller"
+application.register("dark-mode-toggle", DarkModeToggleController)
+
 import ExpandableFabController from "./expandable_fab_controller"
 application.register("expandable-fab", ExpandableFabController)
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -36,22 +36,47 @@
 
     <!-- ===== ヘッダー ===== -->
     <header class="flex justify-between items-center p-4 w-full max-w-4xl mx-auto">
-      <!-- 左側：ダークモード切り替えボタン -->
+      <!-- 左側：ダークモード切り替えトグルスイッチ（iOS風） -->
       <div class="w-24 flex justify-start items-center pl-2 sm:pl-0">
-        <button
-          type="button"
-          id="darkModeToggle"
-          aria-label="ダークモード切り替え"
-          class="flex flex-col items-center justify-center text-gray-700 dark:text-gray-300 hover:text-primary dark:hover:text-sky-400 transition-colors p-2 rounded-lg">
-          <!-- ライトモード時に表示：月のアイコンと「ダーク」テキスト -->
-          <!-- dark:!hidden = ダークモード時は必ず非表示にする（!で優先度を上げる） -->
-          <span class="material-symbols-outlined text-2xl dark:!hidden">dark_mode</span>
-          <span class="text-[8px] mt-0.5 font-medium dark:!hidden">ダーク</span>
-          <!-- ダークモード時に表示：太陽のアイコンと「ライト」テキスト -->
-          <!-- !hidden = 最初は非表示、dark:!block = ダークモード時は必ず表示する（!で優先度を上げる） -->
-          <span class="material-symbols-outlined text-2xl !hidden dark:!block">light_mode</span>
-          <span class="text-[8px] mt-0.5 font-medium !hidden dark:!block">ライト</span>
-        </button>
+        <!-- Stimulusコントローラーでダークモード切り替えを制御 -->
+        <div data-controller="dark-mode-toggle">
+          <!-- トグルスイッチのボタン -->
+          <button
+            type="button"
+            data-action="click->dark-mode-toggle#toggle"
+            aria-label="ダークモード切り替え"
+            class="relative flex items-center">
+
+            <!-- トグルスイッチの背景 -->
+            <div
+              data-dark-mode-toggle-target="toggle"
+              class="w-14 h-8 bg-gray-300 rounded-full shadow-inner transition-all duration-300 ease-in-out">
+
+              <!-- スライダー（丸いつまみ） -->
+              <div
+                data-dark-mode-toggle-target="slider"
+                class="absolute top-1 left-1 w-6 h-6 bg-white rounded-full shadow-md transition-transform duration-300 ease-in-out flex items-center justify-center"
+                style="transform: translateX(0);">
+
+                <!-- 月のアイコン（ライトモード時） -->
+                <span
+                  data-dark-mode-toggle-target="icon"
+                  data-icon="moon"
+                  class="material-symbols-outlined text-sm text-gray-700 transition-all duration-200 opacity-100 scale-100">
+                  dark_mode
+                </span>
+
+                <!-- 太陽のアイコン（ダークモード時） -->
+                <span
+                  data-dark-mode-toggle-target="icon"
+                  data-icon="sun"
+                  class="material-symbols-outlined text-sm text-yellow-500 absolute transition-all duration-200 opacity-0 scale-0">
+                  light_mode
+                </span>
+              </div>
+            </div>
+          </button>
+        </div>
       </div>
 
       <!-- 中央：ロゴ -->


### PR DESCRIPTION
ダークモード切り替えボタンをiOS風のトグルスイッチに刷新しました。

主な変更点：
- Stimulusコントローラー（dark_mode_toggle_controller.js）を新規作成
- iOS風のトグルスイッチUIを実装（スライドアニメーション付き）
- 既存のdark_mode.jsを削除し、Stimulusで統一
- トグルスイッチの背景色がテーマに応じて変化
- アイコンがスムーズに切り替わるアニメーション

実装内容：
- ライトモード時：グレー背景 + 月アイコン（左側）
- ダークモード時：青グラデーション背景 + 太陽アイコン（右側）
- スライダーが左右に滑らかに移動
- 0.3秒のトランジションアニメーション