### PR TITLE
モバイルファーストのレスポンシブ化の微調整

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -59,19 +59,19 @@
                   class="absolute top-0.5 left-0.5 w-4 h-4 sm:w-5 sm:h-5 bg-white rounded-full shadow-md transition-transform duration-300 ease-in-out flex items-center justify-center"
                   style="transform: translateX(0);">
 
-                  <!-- 月のアイコン（ライトモード時・15％拡大） -->
+                  <!-- 月のアイコン（ライトモード時・モバイル：15％拡大） -->
                   <span
                     data-dark-mode-toggle-target="icon"
                     data-icon="moon"
-                    class="material-symbols-outlined text-[12px] sm:text-sm text-gray-700 transition-all duration-200 opacity-100 scale-100">
+                    class="material-symbols-outlined text-[12px] sm:text-xs text-gray-700 transition-all duration-200 opacity-100 scale-100">
                     dark_mode
                   </span>
 
-                  <!-- 太陽のアイコン（ダークモード時・15％拡大） -->
+                  <!-- 太陽のアイコン（ダークモード時・モバイル：15％拡大） -->
                   <span
                     data-dark-mode-toggle-target="icon"
                     data-icon="sun"
-                    class="material-symbols-outlined text-[12px] sm:text-sm text-yellow-500 absolute transition-all duration-200 opacity-0 scale-0">
+                    class="material-symbols-outlined text-[12px] sm:text-xs text-yellow-500 absolute transition-all duration-200 opacity-0 scale-0">
                     light_mode
                   </span>
                 </div>
@@ -102,14 +102,14 @@
                 data: { turbo_method: :delete, turbo_confirm: "ログアウトしますか?" },
                 aria_label: "ログアウト",
                 class: "w-6 h-6 sm:w-10 sm:h-10 rounded-full bg-gradient-to-br from-red-400 to-red-600 dark:from-red-500 dark:to-red-700 flex items-center justify-center shadow-md hover:shadow-lg hover:scale-110 transition-all duration-300" do %>
-              <span class="material-symbols-outlined text-base sm:text-2xl text-white">logout</span>
+              <span class="material-symbols-outlined text-base sm:text-xl text-white">logout</span>
             <% end %>
           <% else %>
             <!-- ログインボタン（青いグラデーション丸ボタン・モバイル：小、PC：中） -->
             <%= link_to new_user_session_path,
                 aria_label: "ログイン",
                 class: "w-6 h-6 sm:w-10 sm:h-10 rounded-full bg-gradient-to-br from-blue-400 to-blue-600 dark:from-blue-500 dark:to-blue-700 flex items-center justify-center shadow-md hover:shadow-lg hover:scale-110 transition-all duration-300" do %>
-              <span class="material-symbols-outlined text-base sm:text-2xl text-white">login</span>
+              <span class="material-symbols-outlined text-base sm:text-xl text-white">login</span>
             <% end %>
           <% end %>
         </div>


### PR DESCRIPTION
今回の修正内容まとめ
モバイルファーストのレスポンシブ化

ヘッダーとボトムナビゲーションをモバイルで約40％縮小、PC（640px以上）で拡大
ヘッダーアイコンの調整

ダークモード切り替えとログイン/ログアウトボタンのアイコンをモバイルのみ15％拡大
PC側は元のサイズを維持
ボトムナビゲーションの簡素化

「ホーム」「散歩」「投稿」「記録」「ランキング」の文字ラベルをすべて削除
アイコンのみのすっきりしたデザインに変更
変更ファイル: app/views/layouts/application.html.erb