### PR TITLE
fix: フォームネスト問題を修正して保存ボタンを動作させる

### DIFF
--- a/app/views/walks/_form.html.erb
+++ b/app/views/walks/_form.html.erb
@@ -48,11 +48,10 @@
       </p>
     <% else %>
       <!-- Google Fit未連携の場合 -->
-      <%= button_to user_google_oauth2_omniauth_authorize_path,
+      <%= link_to user_google_oauth2_omniauth_authorize_path,
           method: :post,
           data: { turbo: false },
-          class: "w-full bg-white dark:bg-gray-700 hover:bg-gray-50 dark:hover:bg-gray-600 text-gray-800 dark:text-gray-200 font-bold py-3 px-6 rounded-lg shadow-md transition-colors border border-gray-300 dark:border-gray-600",
-          form_class: "w-full" do %>
+          class: "w-full inline-block bg-white dark:bg-gray-700 hover:bg-gray-50 dark:hover:bg-gray-600 text-gray-800 dark:text-gray-200 font-bold py-3 px-6 rounded-lg shadow-md transition-colors border border-gray-300 dark:border-gray-600" do %>
         <div class="flex items-center justify-center space-x-2">
           <svg class="w-5 h-5" viewBox="0 0 24 24">
             <path fill="#4285F4" d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"/>


### PR DESCRIPTION
- Google連携ボタンを`button_to`から`link_to`に変更
- `button_to`は内部的にformタグを生成し、メインフォーム内にネストされていた
- HTMLの仕様ではフォームのネストは禁止されており、これが保存ボタンの動作不良の原因
- `link_to`に変更することでフォームネストを解消し、メインフォームが正常に動作するようになる