### PR TITLE
feat: 目標距離設定機能の実装とUI改善

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -16,7 +16,7 @@ class ApplicationController < ActionController::Base
     devise_parameter_sanitizer.permit(:sign_up, keys: [ :name ])
 
     # アカウント更新時に追加フィールドを許可する場合
-    devise_parameter_sanitizer.permit(:account_update, keys: [ :name ])
+    devise_parameter_sanitizer.permit(:account_update, keys: [ :name, :target_distance ])
   end
   # ログアウト後のリダイレクト先を指定
   def after_sign_out_path_for(resource_or_scope)

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -30,5 +30,8 @@ class HomeController < ApplicationController
       lat: location[:latitude],
       lon: location[:longitude]
     )
+
+    # 今日の散歩記録を取得
+    @today_walk = current_user.walks.find_by(walked_on: Date.today)
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -35,8 +35,8 @@ class UsersController < ApplicationController
       params[:user].delete(:password_confirmation)
     end
 
-    # :email, :password, :password_confirmation を追加で許可します
-    params.require(:user).permit(:name, :email, :password, :password_confirmation)
+    # :email, :password, :password_confirmation, :target_distance を追加で許可します
+    params.require(:user).permit(:name, :email, :password, :password_confirmation, :target_distance)
   end
 
   # セキュリティ対策：ログインユーザー以外が編集画面にアクセスしようとしたら弾く

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,6 +9,12 @@ class User < ApplicationRecord
   # dependent: :destroy は、ユーザーが削除されたときに関連する散歩記録も一緒に削除する
   has_many :walks, dependent: :destroy
 
+  # 目標距離のバリデーション
+  # 1. 必須であること（デフォルト値があるため通常は問題ないが、念のため）
+  # 2. 数値であること
+  # 3. 0より大きいこと
+  validates :target_distance, presence: true, numericality: { only_integer: true, greater_than: 0 }
+
   # Google OAuth2認証のコールバック処理
   # OmniAuthから返されたデータを使って、ユーザー情報とトークンを保存する
   def self.from_omniauth(auth)

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -8,6 +8,8 @@
     <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
   </div>
 
+
+
   <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
     <div>Currently waiting confirmation for: <%= resource.unconfirmed_email %></div>
   <% end %>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -3,22 +3,31 @@
 <div class="flex-1 p-4 pb-24 w-full max-w-2xl mx-auto space-y-4">
 
   <!-- 今日の散歩ダッシュボード -->
-  <%= link_to walks_path, class: "block bg-gradient-to-br from-blue-300 to-indigo-400 dark:from-blue-600 dark:to-indigo-700 text-white p-6 rounded-3xl shadow-lg transition-all duration-300 hover:shadow-lg hover:scale-[1.01] drop-shadow-2xl" do %>
+  <!-- 今日の散歩ダッシュボード -->
+  <div class="relative block bg-gradient-to-br from-blue-300 to-indigo-400 dark:from-blue-600 dark:to-indigo-700 text-white p-6 rounded-3xl shadow-lg transition-all duration-300 hover:shadow-lg hover:scale-[1.01] drop-shadow-2xl group">
+    <!-- カード全体をリンク化（Stretched Link） -->
+    <%= link_to "", walks_path, class: "absolute inset-0 z-0 rounded-3xl" %>
+
     <p class="text-xl font-bold font-bold opacity-90 text-shadow">今日の散歩</p>
 
     <!-- 距離と目標距離 -->
-<div class="flex justify-between items-baseline mt-2">
-  <p class="text-4xl font-bold text-shadow">
-    2,000<span class="text-base font-medium ml-1 text-shadow">m</span>
-  </p>
-  <p class="text-lg font-bold opacity-90 text-shadow">
-    / 5,000m
-  </p>
-</div>
+    <div class="flex justify-between items-baseline mt-2">
+      <p class="text-4xl font-bold text-shadow">
+        <%= number_with_delimiter((@today_walk&.distance.to_f * 1000).to_i) %><span class="text-base font-medium ml-1 text-shadow">m</span>
+      </p>
+      <p class="text-lg font-bold opacity-90 text-shadow relative z-10">
+        <%= link_to edit_user_path(current_user), class: "text-white hover:text-white transition-all inline-flex items-center gap-0.5 group" do %>
+          <span class="group-hover:underline decoration-white/50 underline-offset-4">
+            / <%= number_with_delimiter(current_user.target_distance) %>m
+          </span>
+          <span class="material-symbols-outlined text-[16px] opacity-70 group-hover:opacity-100 transition-opacity">settings</span>
+        <% end %>
+      </p>
+    </div>
 
     <!-- 距離のプログレスバー -->
     <div class="w-full bg-white/30 rounded-full h-2.5 my-4">
-      <div class="bg-gradient-to-r from-lime-300 to-green-400 h-2.5 rounded-full shadow-md" style="width: 40%"></div>
+      <div class="bg-gradient-to-r from-lime-300 to-green-400 h-2.5 rounded-full shadow-md" style="width: <%= ((@today_walk&.distance.to_f * 1000) / current_user.target_distance.to_f * 100).clamp(0, 100) %>%"></div>
     </div>
 
     <!-- 消費カロリー -->
@@ -27,18 +36,18 @@
       <div class="flex items-center space-x-2">
         <span class="material-symbols-outlined text-4xl animate-pulse-fast text-shadow w-9 h-9 overflow-hidden">directions_walk</span>
         <div>
-          <p class="font-bold text-lg text-shadow">5,234 歩</p>
+          <p class="font-bold text-lg text-shadow"><%= number_with_delimiter(@today_walk&.steps || 0) %> 歩</p>
         </div>
       </div>
       <!-- 消費カロリー -->
       <div class="flex items-center space-x-2">
         <span class="material-symbols-outlined text-4xl animate-pulse-fast text-shadow">local_fire_department</span>
         <div>
-          <p class="font-bold text-lg text-shadow">312 kcal</p>
+          <p class="font-bold text-lg text-shadow"><%= number_with_delimiter(@today_walk&.calories_burned || 0) %> kcal</p>
         </div>
       </div>
     </div>
-  <% end %>
+  </div>
 
   <!-- 天気予報とランキングのグリッド -->
   <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -43,6 +43,18 @@
         </div>
         <p class="text-xs text-gray-500 mt-1 ml-1">ランキングや投稿などで他のユーザーに表示されます</p>
       </div>
+
+      <div>
+        <%= f.label :target_distance, "目標距離 (m)", class: "block text-sm font-bold text-gray-700 dark:text-gray-300 mb-2" %>
+        <div class="relative group">
+          <span class="material-symbols-outlined absolute left-3 top-1/2 -translate-y-1/2 text-gray-400 group-focus-within:text-blue-500 transition-colors">flag</span>
+          <%= f.number_field :target_distance,
+              step: 100,
+              placeholder: "例: 5000",
+              class: "w-full pl-10 pr-4 py-3 bg-gray-50 dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-xl focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-all outline-none text-gray-800 dark:text-gray-200 placeholder-gray-400 shadow-inner" %>
+        </div>
+        <p class="text-xs text-gray-500 mt-1 ml-1">1日の目標距離をメートル単位で設定します（デフォルト: 5000）</p>
+      </div>
       <%# セキュリティ設定エリア（メール・パスワード） %>
       <div class="border-t border-gray-100 dark:border-gray-700 pt-6 mt-6">
         <h3 class="text-sm font-bold text-gray-700 dark:text-gray-300 mb-4">セキュリティ設定</h3>

--- a/db/migrate/20251127074734_add_target_distance_to_users.rb
+++ b/db/migrate/20251127074734_add_target_distance_to_users.rb
@@ -1,0 +1,5 @@
+class AddTargetDistanceToUsers < ActiveRecord::Migration[7.2]
+  def change
+    add_column :users, :target_distance, :integer, default: 3000, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_11_25_035721) do
+ActiveRecord::Schema[7.2].define(version: 2025_11_27_074734) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -28,6 +28,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_11_25_035721) do
     t.datetime "google_expires_at"
     t.string "avatar_url"
     t.string "name"
+    t.integer "target_distance", default: 5000, null: false
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,6 +1,25 @@
 require "rails_helper"
 
 RSpec.describe User, type: :model do
+  describe "バリデーション" do
+    it "有効な目標距離であれば有効であること" do
+      user = User.new(email: "test@example.com", password: "password", target_distance: 5000)
+      expect(user).to be_valid
+    end
+
+    it "目標距離がない場合は無効であること" do
+      user = User.new(email: "test@example.com", password: "password", target_distance: nil)
+      user.valid?
+      expect(user.errors[:target_distance]).to include("を入力してください")
+    end
+
+    it "目標距離が0以下の場合は無効であること" do
+      user = User.new(email: "test@example.com", password: "password", target_distance: 0)
+      user.valid?
+      expect(user.errors[:target_distance]).to include("は0より大きい値にしてください")
+    end
+  end
+
   describe ".from_omniauth" do
     # OmniAuthのモックデータを作成
     # 実際のGoogle認証の代わりに、このハッシュデータを使用します


### PR DESCRIPTION
## 概要
ユーザーが毎日の目標距離を設定できる機能を追加し、ホーム画面のダッシュボード（今日の散歩）と連携させました。
また、ユーザーからのフィードバックに基づき、設定への導線やUIの改善を行いました。
## 変更点
### ✨ 機能面
- **DB:** `users` テーブルに `target_distance` カラムを追加（デフォルト: 3,000m）。
- **Model:** `User` モデルに `target_distance` のバリデーション（数値、0より大きい）を追加。
- **Controller:** `UsersController` で `target_distance` の更新を許可。
- **View:** アカウント設定画面（`users/edit`）に目標距離の入力欄を追加。
### 🎨 UI/UX面
- **ダッシュボード連携:** ホーム画面の目標数値を、設定された値（`current_user.target_distance`）に動的に変更。
- **プログレスバー:** 目標距離に基づいて進捗率を計算するように修正。
- **導線改善:**
    - ダッシュボードの目標数値（例: `/ 5,000m`）をクリックすると、設定画面へ遷移するようにリンク化。
    - リンクであることが分かるように、数字の横に歯車アイコン（⚙️）を追加。
    - マウスホバー時、数字部分にのみ下線を表示し、アイコンは明るくする演出を追加。
- **レイアウト修正:**
    - カード全体をクリック可能にしつつ、内部の目標設定リンクも機能するように「Stretched Link」パターンを採用（`z-index`調整）。
    - ネストされたリンク（`<a>`の中に`<a>`）によるレイアウト崩れを修正。
## ✅ テスト
- `spec/models/user_spec.rb` に `target_distance` のバリデーションテストを追加し、パスすることを確認。
- 実機での動作確認済み（設定変更、ダッシュボード反映、リンク遷移）。