### PR TITLE
fix: Google認証時のユーザー作成エラーを修正（target_distanceのデフォルト値を設定）

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -39,7 +39,8 @@ class User < ApplicationRecord
         google_token: auth.credentials.token,
         google_refresh_token: auth.credentials.refresh_token,
         google_expires_at: Time.at(auth.credentials.expires_at),
-        avatar_url: auth.info.image # アバター画像を保存
+        avatar_url: auth.info.image, # アバター画像を保存
+        target_distance: 3000 # バリデーション回避のため明示的にデフォルト値を設定
       )
     end
 

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -3,7 +3,6 @@
 <div class="flex-1 p-4 pb-24 w-full max-w-2xl mx-auto space-y-4">
 
   <!-- 今日の散歩ダッシュボード -->
-  <!-- 今日の散歩ダッシュボード -->
   <div class="relative block bg-gradient-to-br from-blue-300 to-indigo-400 dark:from-blue-600 dark:to-indigo-700 text-white p-6 rounded-3xl shadow-lg transition-all duration-300 hover:shadow-lg hover:scale-[1.01] drop-shadow-2xl group">
     <!-- カード全体をリンク化（Stretched Link） -->
     <%= link_to "", walks_path, class: "absolute inset-0 z-0 rounded-3xl" %>


### PR DESCRIPTION
## 概要
本番環境でのGoogle認証ログインにおいて、新規登録時にエラーが発生する問題を修正しました。
また、修正に必要なデータベースおよびモデルへの変更（目標距離機能のバックエンド実装）を含みます。
※ ホーム画面（ダッシュボード）のUI変更は含みません。
## 変更点
### 🐛 バグ修正
- **Google認証:** 新規登録時に `target_distance` のバリデーションエラー（必須チェック）によりログインできない問題を修正。
    - `User.from_omniauth` メソッド内で、ユーザー作成時にデフォルト値（3000）を明示的に設定するように変更。
### ✨ 必要な機能実装（修正の前提）
- **DB:** `users` テーブルに `target_distance` カラムを追加（デフォルト: 3,000m）。
- **Model:** `User` モデルに `target_distance` のバリデーション（数値、0より大きい）を追加。
- **Controller:** `UsersController` で `target_distance` の更新を許可。
- **View:** アカウント設定画面（`users/edit`）に目標距離の入力欄を追加。
## ✅ テスト
- `spec/models/user_spec.rb` に `target_distance` のバリデーションテストを追加し、パスすることを確認。
- Google認証によるユーザー作成が正常に行われることを確認済み。