### PR TITLE
本番環境でのGoogle認証エラー修正（SameSite属性変更）

### DIFF
--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,6 +1,6 @@
 # Be sure to restart your server when you modify this file.
 
 Rails.application.config.session_store :cookie_store,
-  key: "_tekumemo_session_v2", # キーを変更して古いセッションを無効化
-  secure: Rails.env.production?, # 本番環境のみSecure属性を有効化（HTTPS必須）
-  same_site: :lax               # クロスサイトリクエスト（OAuthコールバック）のためにLaxを指定
+  key: "_tekumemo_session_v3",
+  secure: Rails.env.production?,
+  same_site: Rails.env.production? ? :none : :lax


### PR DESCRIPTION
### [MODIFY] config/initializers/session_store.rb
本番環境（`Rails.env.production?`）の場合のみ、以下の設定を適用します。
- `same_site`: `:none` (Laxから変更)
- `secure`: `true` (Noneにする場合は必須)
- `key`: `_tekumemo_session_v3` (キャッシュクリアのため変更)