### PR TITLE
本番環境でのGoogle認証エラー修正（Origin検証無効化）

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -26,6 +26,7 @@ Rails.application.configure do
   # SSL設定
   config.force_ssl = true
   config.assume_ssl = true # Renderなどのロードバランサ配下でHTTPSとして認識させる
+  config.action_controller.forgery_protection_origin_check = false # Render対策：Originヘッダー検証をスキップ
 
   # ログ設定
   config.logger = ActiveSupport::Logger.new(STDOUT)

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,6 +1,6 @@
 # Be sure to restart your server when you modify this file.
 
 Rails.application.config.session_store :cookie_store,
-  key: "_tekumemo_session_v3",
+  key: "_tekumemo_session_v4",
   secure: Rails.env.production?,
   same_site: Rails.env.production? ? :none : :lax


### PR DESCRIPTION
Origin検証の無効化:
- config/environments/production.rb に config.action_controller.forgery_protection_origin_check = false を追加しました。これにより、Renderのロードバランサ経由でOriginヘッダーが不一致になる問題を回避します。
- セッションキーの更新:
_tekumemo_session_v4 に更新し、キャッシュをクリアしました。