### PR TITLE
fix app/javascript/controllers/index.jsとapp/views/home/index.html.erbファイルのステージング漏れ

### DIFF
--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -4,6 +4,9 @@
 
 import { application } from "./application"
 
+import CounterController from "./counter_controller"
+application.register("counter", CounterController)
+
 import DarkModeToggleController from "./dark_mode_toggle_controller"
 application.register("dark-mode-toggle", DarkModeToggleController)
 

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -208,5 +208,4 @@
       <p class="mt-2 text-sm text-white/90 text-shadow">スクロールテスト用</p>
     </div>
   </div>
-
 </div>


### PR DESCRIPTION
Gemfileの内容とGemfile.lockの内容が一致していないとデプロイログにはあった
実際にはapp/javascript/controllers/index.jsとapp/views/home/index.html.erbファイルのステージング漏れが原因でした
再発防止のため、mainブランチではなく、最新の作業ブランチのコミットで再デプロイできるように変更