### PR TITLE
UI改善: ホーム画面の配色統一とレイアウト調整

### DIFF
--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -4,7 +4,7 @@
 
   <!-- 今日の散歩ダッシュボード -->
   <!-- 今日の散歩ダッシュボード -->
-  <div class="relative block bg-gradient-to-br from-blue-300 to-indigo-400 dark:from-blue-600 dark:to-indigo-700 text-white p-6 rounded-3xl shadow-lg transition-all duration-300 hover:shadow-lg hover:scale-[1.01] drop-shadow-2xl group">
+  <div class="relative block bg-gradient-to-br from-cyan-400 to-indigo-500 dark:from-cyan-600 dark:to-indigo-800 text-white p-6 rounded-3xl shadow-lg transition-all duration-300 hover:shadow-lg hover:scale-[1.01] drop-shadow-2xl group">
     <!-- カード全体をリンク化（Stretched Link） -->
     <%= link_to "", walks_path, class: "absolute inset-0 z-0 rounded-3xl" %>
 
@@ -55,7 +55,7 @@
   <!-- 天気予報とランキングのグリッド -->
   <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
     <!-- 天気予報カード（コンパクト版） -->
-    <div class="bg-gradient-to-br from-sky-300 to-blue-400 dark:from-sky-700 dark:to-blue-800 rounded-3xl shadow-xl overflow-hidden transform transition-all duration-300 hover:shadow-lg hover:scale-[1.01] drop-shadow-2xl">
+    <div class="bg-gradient-to-br from-sky-400 to-blue-600 dark:from-sky-600 dark:to-blue-800 rounded-3xl shadow-xl overflow-hidden transform transition-all duration-300 hover:shadow-lg hover:scale-[1.01] drop-shadow-2xl">
       <!-- カードヘッダー -->
       <div class="px-3 py-1.5 bg-white/10 dark:bg-black/20 backdrop-blur-sm border-b border-white/20">
         <div class="flex items-center justify-center">
@@ -119,7 +119,7 @@
     </div>
 
     <!-- ランキングカード -->
-<div class="bg-gradient-to-br from-blue-400 to-blue-600 dark:from-blue-600 dark:to-blue-800 rounded-3xl shadow-xl overflow-hidden transform transition-all duration-300 hover:shadow-2xl hover:scale-[1.01] drop-shadow-2xl">
+<div class="bg-gradient-to-br from-sky-400 to-blue-700 dark:from-sky-600 dark:to-blue-900 rounded-3xl shadow-xl overflow-hidden transform transition-all duration-300 hover:shadow-2xl hover:scale-[1.01] drop-shadow-2xl">
   <div class="p-3 h-full flex items-center justify-between relative">
 
     <div class="flex flex-col justify-center z-10">
@@ -165,7 +165,7 @@
   <!-- 下段グリッド：最新の投稿とメモ帳 -->
   <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
     <!-- 最新の投稿カード -->
-    <div class="bg-gradient-to-br from-sky-200 to-blue-300 dark:from-blue-800/90 dark:to-slate-900/90 backdrop-blur-md border border-blue-200 dark:border-blue-700/30 p-4 rounded-3xl shadow-xl transition-all duration-300 hover:shadow-2xl hover:scale-[1.01] group">
+    <div class="bg-gradient-to-br from-white/80 to-blue-50/50 dark:from-slate-800/60 dark:to-slate-900/60 backdrop-blur-xl border border-white/60 dark:border-white/10 p-4 rounded-3xl shadow-xl transition-all duration-300 hover:shadow-2xl hover:scale-[1.01] group">
       <h3 class="font-bold text-blue-900 dark:text-blue-100 mb-3 flex items-center">
         <span class="material-symbols-outlined mr-2 text-blue-600 dark:text-blue-400 group-hover:text-blue-700 dark:group-hover:text-blue-300 transition-colors">article</span>
         最新の投稿
@@ -179,14 +179,14 @@
     </div>
 
     <!-- メモ帳カード -->
-    <%= link_to "https://keep.google.com/", target: "_blank", rel: "noopener noreferrer", class: "block bg-gradient-to-br from-sky-200 to-cyan-300 dark:from-sky-800 dark:to-cyan-900 p-5 rounded-3xl shadow-xl border border-cyan-100 dark:border-cyan-800 relative overflow-hidden transition-all duration-300 hover:shadow-2xl hover:scale-[1.01] drop-shadow-2xl group" do %>
+    <%= link_to "https://keep.google.com/", target: "_blank", rel: "noopener noreferrer", class: "block bg-gradient-to-br from-white/80 to-cyan-50/50 dark:from-slate-800/60 dark:to-slate-900/60 backdrop-blur-xl border border-white/60 dark:border-white/10 p-5 rounded-3xl shadow-xl relative overflow-hidden transition-all duration-300 hover:shadow-2xl hover:scale-[1.01] drop-shadow-2xl group" do %>
       <div class="flex justify-between items-end relative z-10">
         <div>
           <h3 class="font-bold text-lg mb-2 text-cyan-900 dark:text-cyan-100 text-shadow-sm">メモ帳</h3>
           <span class="material-symbols-outlined text-4xl text-cyan-700/50 dark:text-cyan-300/50 -ml-1 transform -rotate-12">note_stack</span>
         </div>
         <div>
-          <button type="button" class="bg-white/80 dark:bg-gray-700/80 text-cyan-700 dark:text-cyan-200 font-bold py-2 px-4 rounded-full shadow-md flex items-center space-x-1 group-hover:bg-white dark:group-hover:bg-gray-700 transition-colors">
+          <button type="button" class="bg-white dark:bg-gray-700/80 text-green-600 dark:text-cyan-200 font-bold py-2 px-4 rounded-full shadow-lg flex items-center space-x-1 group-hover:bg-white dark:group-hover:bg-gray-700 transition-colors">
             <span class="material-symbols-outlined text-lg w-5 h-5 overflow-hidden">add</span>
             <span class="text-sm font-bold">メモ帳を開く</span>
           </button>


### PR DESCRIPTION
## 概要
ホーム画面とレイアウトのデザインを大幅に改善し、「クリスタル・ブルー」をテーマに配色を統一しました。
## 変更点
- **ホーム画面**:
  - カード配色を青・水色・インディゴ系で統一。
  - ダッシュボード、天気、ランキングカードのグラデーションを強化し、リッチな見た目に。
  - 最新の投稿とメモ帳カードを「Glassmorphism（すりガラス）」デザインに変更し、透明感を演出。
  - 全てのカードの影を強め、立体感を向上。
  - お知らせカードの「NEW」バッジを日付の下に配置し、情報を整理。
- **レイアウト**:
  - ヘッダーにすりガラス効果（backdrop-blur）を追加。
  - 全体の背景色を青みがかったグレーに微調整。
  - FAB（追加ボタン）を暖色グラデーションに変更し、位置を調整。
  - アバター背景色を寒色グラデーションに変更。