### PR TITLE
feat: ページネーション機能の実装とUI刷新

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,6 +18,7 @@ gem "google-apis-fitness_v1"
 gem "simple_calendar", "~> 3.0"
 gem "dotenv-rails"
 gem "geocoder"
+gem "kaminari"
 
 group :development, :test do
   gem "debug", platforms: %i[ mri windows ], require: "debug/prelude"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -173,6 +173,18 @@ GEM
     json (2.16.0)
     jwt (3.1.2)
       base64
+    kaminari (1.2.2)
+      activesupport (>= 4.1.0)
+      kaminari-actionview (= 1.2.2)
+      kaminari-activerecord (= 1.2.2)
+      kaminari-core (= 1.2.2)
+    kaminari-actionview (1.2.2)
+      actionview
+      kaminari-core (= 1.2.2)
+    kaminari-activerecord (1.2.2)
+      activerecord
+      kaminari-core (= 1.2.2)
+    kaminari-core (1.2.2)
     language_server-protocol (3.17.0.5)
     lint_roller (1.1.0)
     logger (1.7.0)
@@ -435,6 +447,7 @@ DEPENDENCIES
   google-apis-fitness_v1
   jbuilder
   jsbundling-rails
+  kaminari
   omniauth-google-oauth2
   omniauth-rails_csrf_protection (~> 1.0.2)
   pg (~> 1.1)

--- a/app/controllers/walks_controller.rb
+++ b/app/controllers/walks_controller.rb
@@ -9,7 +9,7 @@ class WalksController < ApplicationController
   def index
     # ログインしているユーザーの散歩記録だけを取得する
     # Walkモデルのdefault_scopeにより、日付順（新しい順）で自動ソートされる
-    @walks = current_user.walks.recent
+    @walks = current_user.walks.recent.page(params[:page]).per(10)
   end
 
   # 散歩記録詳細ページ（GET /walks/:id）

--- a/app/views/kaminari/_first_page.html.erb
+++ b/app/views/kaminari/_first_page.html.erb
@@ -1,0 +1,3 @@
+<%= link_to url, remote: remote, class: "hidden sm:flex items-center justify-center w-10 h-10 rounded-full bg-white dark:bg-slate-800 text-gray-400 dark:text-gray-500 shadow-sm border border-gray-100 dark:border-slate-700 hover:bg-sky-50 dark:hover:bg-slate-700 hover:text-sky-600 dark:hover:text-sky-400 hover:shadow-md transition-all duration-300 group mr-2", aria: { label: t('views.pagination.first') } do %>
+  <span class="material-symbols-outlined text-xl group-hover:scale-110 transition-transform">first_page</span>
+<% end %>

--- a/app/views/kaminari/_gap.html.erb
+++ b/app/views/kaminari/_gap.html.erb
@@ -1,0 +1,3 @@
+<span class="flex items-center justify-center w-10 h-10 text-gray-300 dark:text-gray-600 select-none">
+  <span class="material-symbols-outlined text-lg">more_horiz</span>
+</span>

--- a/app/views/kaminari/_last_page.html.erb
+++ b/app/views/kaminari/_last_page.html.erb
@@ -1,0 +1,3 @@
+<%= link_to url, remote: remote, class: "hidden sm:flex items-center justify-center w-10 h-10 rounded-full bg-white dark:bg-slate-800 text-gray-400 dark:text-gray-500 shadow-sm border border-gray-100 dark:border-slate-700 hover:bg-sky-50 dark:hover:bg-slate-700 hover:text-sky-600 dark:hover:text-sky-400 hover:shadow-md transition-all duration-300 group ml-2", aria: { label: t('views.pagination.last') } do %>
+  <span class="material-symbols-outlined text-xl group-hover:scale-110 transition-transform">last_page</span>
+<% end %>

--- a/app/views/kaminari/_next_page.html.erb
+++ b/app/views/kaminari/_next_page.html.erb
@@ -1,0 +1,3 @@
+<%= link_to url, remote: remote, rel: 'next', class: "flex items-center justify-center w-10 h-10 rounded-full bg-white dark:bg-slate-800 text-gray-500 dark:text-gray-400 shadow-sm border border-gray-100 dark:border-slate-700 hover:bg-sky-50 dark:hover:bg-slate-700 hover:text-sky-600 dark:hover:text-sky-400 hover:shadow-md hover:translate-x-1 transition-all duration-300 group", aria: { label: t('views.pagination.next') } do %>
+  <span class="material-symbols-outlined text-xl group-hover:scale-110 transition-transform">chevron_right</span>
+<% end %>

--- a/app/views/kaminari/_page.html.erb
+++ b/app/views/kaminari/_page.html.erb
@@ -1,0 +1,7 @@
+<% if page.current? %>
+  <span class="flex items-center justify-center w-10 h-10 rounded-full bg-gradient-to-r from-sky-400 to-blue-500 text-white font-bold shadow-lg shadow-sky-200 dark:shadow-[0_0_10px_rgba(14,165,233,0.5)] transform scale-110 transition-all duration-300 cursor-default">
+    <%= page %>
+  </span>
+<% else %>
+  <%= link_to page, url, remote: remote, rel: page.rel, class: "flex items-center justify-center w-10 h-10 rounded-full bg-white dark:bg-slate-800 text-gray-600 dark:text-gray-300 font-medium shadow-sm border border-gray-100 dark:border-slate-700 hover:bg-sky-50 dark:hover:bg-slate-700 hover:text-sky-600 dark:hover:text-sky-400 hover:shadow-md hover:scale-110 hover:border-sky-200 dark:hover:border-sky-500/30 transition-all duration-300" %>
+<% end %>

--- a/app/views/kaminari/_paginator.html.erb
+++ b/app/views/kaminari/_paginator.html.erb
@@ -1,0 +1,15 @@
+<%= paginator.render do -%>
+  <nav class="flex justify-center items-center space-x-2" role="navigation" aria-label="pager">
+    <%= first_page_tag unless current_page.first? %>
+    <%= prev_page_tag unless current_page.first? %>
+    <% each_page do |page| -%>
+      <% if page.left_outer? || page.right_outer? || page.inside_window? -%>
+        <%= page_tag page %>
+      <% elsif !page.was_truncated? -%>
+        <%= gap_tag %>
+      <% end -%>
+    <% end -%>
+    <%= next_page_tag unless current_page.last? %>
+    <%= last_page_tag unless current_page.last? %>
+  </nav>
+<% end -%>

--- a/app/views/kaminari/_prev_page.html.erb
+++ b/app/views/kaminari/_prev_page.html.erb
@@ -1,0 +1,3 @@
+<%= link_to url, remote: remote, rel: 'prev', class: "flex items-center justify-center w-10 h-10 rounded-full bg-white dark:bg-slate-800 text-gray-500 dark:text-gray-400 shadow-sm border border-gray-100 dark:border-slate-700 hover:bg-sky-50 dark:hover:bg-slate-700 hover:text-sky-600 dark:hover:text-sky-400 hover:shadow-md hover:-translate-x-1 transition-all duration-300 group", aria: { label: t('views.pagination.previous') } do %>
+  <span class="material-symbols-outlined text-xl group-hover:scale-110 transition-transform">chevron_left</span>
+<% end %>

--- a/app/views/walks/index.html.erb
+++ b/app/views/walks/index.html.erb
@@ -21,6 +21,11 @@
     <% end %>
   </div>
 
+  <!-- ページネーション（上部） -->
+  <div class="mb-2 flex justify-center">
+    <%= paginate @walks %>
+  </div>
+
   <!-- 散歩記録一覧 -->
   <div class="grid grid-cols-1 gap-6">
     <% if @walks.any? %>
@@ -107,6 +112,12 @@
           </div>
         <% end %>
       <% end %>
+
+    <!-- ページネーション -->
+    <div class="mt-8 flex justify-center">
+      <%= paginate @walks %>
+    </div>
+
     <% else %>
       <!-- 記録がない場合のメッセージ -->
       <div class="col-span-1 bg-gradient-to-br from-white to-sky-50 dark:from-slate-900 dark:to-indigo-950 p-10 rounded-3xl shadow-lg border border-sky-100 dark:border-cyan-500/30 text-center">

--- a/spec/system/walks_pagination_spec.rb
+++ b/spec/system/walks_pagination_spec.rb
@@ -1,0 +1,61 @@
+require 'rails_helper'
+
+RSpec.describe "WalksPagination", type: :system do
+  # Chrome起動オプション（安定稼働用）
+  before do
+    driven_by(:selenium, using: :headless_chrome, screen_size: [ 1400, 1400 ]) do |driver_option|
+      driver_option.add_argument('--no-sandbox')
+      driver_option.add_argument('--disable-dev-shm-usage')
+      driver_option.add_argument('--headless=new')
+      driver_option.add_argument('--disable-gpu')
+      driver_option.add_argument('--disable-infobars')
+      driver_option.add_argument('--disable-extensions')
+    end
+  end
+
+  let(:user) { User.create!(email: "pagination_test@example.com", password: "password", name: "ページネーション太郎") }
+
+  before do
+    # 15件のデータを作成
+    # 場所0: 今日, 場所1: 昨日 ... 場所14: 14日前
+    15.times do |i|
+      Walk.create!(
+        user: user,
+        walked_on: Date.today - i.days,
+        location: "場所#{i}",
+        distance: 1.0,
+        duration: 10,
+        steps: 1000,
+        calories_burned: 50
+      )
+    end
+
+    # ログイン処理
+    visit new_user_session_path
+    fill_in "user_email", with: user.email
+    fill_in "login-password-field", with: user.password
+    click_button "ログインする"
+    expect(page).to have_content "ログインしました"
+  end
+
+  it "ページネーションが表示され、ページ遷移ができること" do
+    visit walks_path
+
+    # 1ページ目の確認（日付が新しい順なので、場所0〜9が表示されるはず）
+    expect(page).to have_content("場所0") # 今日の記録
+    expect(page).to have_content("場所9") # 9日前の記録
+    expect(page).not_to have_content("場所10") # 10日前の記録（2ページ目）
+
+    # ページネーションの存在確認
+    expect(page).to have_selector('nav[role="navigation"]')
+
+    # 2ページ目へ移動（「次へ」ボタンをクリック）
+    # アイコン化されていますが、rel="next" 属性で特定します
+    find('a[rel="next"]').click
+
+    # 2ページ目の確認
+    expect(page).to have_content("場所10")
+    expect(page).to have_content("場所14")
+    expect(page).not_to have_content("場所0")
+  end
+end


### PR DESCRIPTION
# ページネーション機能の実装とUI刷新
## 概要
散歩記録一覧ページ（`/walks`）にページネーション機能を実装しました。
1ページあたりの表示件数を10件とし、過去の記録へスムーズにアクセスできるようにしました。
また、ページネーションのデザインをTailwind CSSを用いてモダンでポップなスタイルに刷新しています。
## 変更点
- **Gem追加**: `kaminari` を導入。
- **コントローラー**: `WalksController#index` で `.page(params[:page]).per(10)` を使用するように変更。
- **ビュー**:
    - `kaminari` のビューファイルを生成し、Tailwind CSSでカスタマイズ。
    - アイコン（Material Symbols）を使用し、ホバーアニメーションを追加。
    - スマホとPCで表示を切り替えるレスポンシブ対応。
- **テスト**: ページネーションの動作検証用 System Spec を追加。
## デザイン詳細
- **形状**: 完全な円形（`rounded-full`）のボタン。
- **配色**: アプリのテーマカラー（Sky Blue）に合わせたグラデーション。
- **インタラクション**: ホバー時に拡大したり、矢印が動くマイクロインタラクションを実装。
## スクリーンショット
ページネーション（全体） 
<img width="954" height="745" alt="image" src="https://github.com/user-attachments/assets/fa326bdc-fc24-4958-9459-18fe95cb7b33" />
