### PR TITLE
refactor: 🏗️ Usersテーブル正規化リファクタリング計画

### DIFF
--- a/docs/refactoring_plan_users_table.md
+++ b/docs/refactoring_plan_users_table.md
@@ -1,0 +1,114 @@
+# Users テーブル正規化リファクタリング計画
+
+## 目的
+
+肥大化した `users` テーブル（27カラム）の責務分離による可読性・保守性・メモリ効率の向上。
+
+## 変更内容
+
+`users` テーブルを以下の4テーブルに分割・正規化を行う。
+
+1. **`users`** (認証・権限): Devise認証、権限管理のみに特化
+2. **`google_accounts`** (外部連携): Google認証トークン・有効期限等の分離
+3. **`user_settings`** (設定): 通知設定、目標距離などの分離
+4. **`user_profiles`** (表示): ユーザー名、アバター情報の分離
+
+## カラム移動計画
+
+| カテゴリ                     | カラム名                                                                                                    | 移動先                        |
+| :--------------------------- | :---------------------------------------------------------------------------------------------------------- | :---------------------------- |
+| 🔐 **認証コア (Devise必須)** | email, encrypted_password, reset_password_token, reset_password_sent_at, remember_created_at                | **users (残す)**              |
+| 🛤 **Devise Trackable**      | sign_in_count, current_sign_in_at, last_sign_in_at, current_sign_in_ip, last_sign_in_ip                     | **users (残す)**              |
+| 🛡 **権限**                  | role                                                                                                        | **users (残す)**              |
+| 👤 **プロフィール**          | name, avatar_url, avatar_type                                                                               | 🚀 **user_profiles (新規)**   |
+| 🔑 **Google OAuth**          | google_uid, google_token, google_refresh_token, google_expires_at                                           | 🚀 **google_accounts (新規)** |
+| ⚙️ **ユーザー設定**          | goal_meters, is_walk_reminder, walk_reminder_time, is_inactive_reminder, inactive_days, is_reaction_summary | 🚀 **user_settings (新規)**   |
+| 🕒 **タイムスタンプ**        | created_at, updated_at                                                                                      | **users (残す)**              |
+
+## 期待される効果
+
+- **メモリ使用量の削減**: 認証時に巨大なトークンや不要な設定値をロードしない
+- **責務の明確化**: "Fat User Model" を解消し、機能ごとのクラス設計へ移行
+- **データ容量の最適化**: 外部連携未使用ユーザーの無駄なレコード作成を防止
+
+## 新規テーブル設計
+
+### google_accounts テーブル
+
+```ruby
+create_table :google_accounts do |t|
+  t.references :user, null: false, foreign_key: true, index: { unique: true }
+  t.string :google_uid, null: false
+  t.text :google_token
+  t.text :google_refresh_token
+  t.datetime :google_expires_at
+  t.timestamps
+end
+```
+
+### user_settings テーブル
+
+```ruby
+create_table :user_settings do |t|
+  t.references :user, null: false, foreign_key: true, index: { unique: true }
+  t.integer :goal_meters, default: 3000, null: false
+  t.boolean :is_walk_reminder, default: false, null: false
+  t.time :walk_reminder_time, default: '19:00'
+  t.boolean :is_inactive_reminder, default: true, null: false
+  t.integer :inactive_days, default: 3, null: false
+  t.boolean :is_reaction_summary, default: true, null: false
+  t.timestamps
+end
+```
+
+### user_profiles テーブル
+
+```ruby
+create_table :user_profiles do |t|
+  t.references :user, null: false, foreign_key: true, index: { unique: true }
+  t.string :name, null: false
+  t.string :avatar_url
+  t.integer :avatar_type, default: 0, null: false
+  t.timestamps
+end
+```
+
+### users テーブル（最終形）
+
+```ruby
+create_table :users do |t|
+  # 認証コア (Devise)
+  t.string :email, default: "", null: false
+  t.string :encrypted_password, default: "", null: false
+  t.string :reset_password_token
+  t.datetime :reset_password_sent_at
+  t.datetime :remember_created_at
+
+  # Trackable
+  t.integer :sign_in_count, default: 0, null: false
+  t.datetime :current_sign_in_at
+  t.datetime :last_sign_in_at
+  t.string :current_sign_in_ip
+  t.string :last_sign_in_ip
+
+  # 権限管理
+  t.integer :role, default: 0, null: false
+
+  t.timestamps
+end
+```
+
+## 実装フェーズ
+
+| Phase   | 対象            | リスク | 工数目安 |
+| :------ | :-------------- | :----- | :------- |
+| Phase 1 | google_accounts | 低     | 2-3時間  |
+| Phase 2 | user_settings   | 中     | 3-4時間  |
+| Phase 3 | user_profiles   | 高     | 4-6時間  |
+| 最終    | 旧カラム削除    | 低     | 1時間    |
+
+## 補足
+
+- 正規化に伴う管理用カラム（ID等）の追加により、物理カラム総数は増加（27→37）
+- N+1問題への対策（`includes` 追加）および既存機能との互換性を確保して実装を実施
+- `is_admin` カラムは `role` に統合済みのため、最終フェーズで削除


### PR DESCRIPTION
# 🏗️ Usersテーブル正規化リファクタリング計画

## 🎯 目的

肥大化した `users` テーブル（27カラム）の責務分離による可読性・保守性・メモリ効率の向上。

---

## 📸 スクリーンショット

<table>
  <tr>
    <td align="center"><strong>正規化対象（旧usersテーブル）</strong></td>
    <td align="center"><strong>正規化後の完成予定</strong></td>
  </tr>
  <tr>
    <td><a href="https://gyazo.com/84a3fa6a2e20bc8f8592d0ef5e35d005"><img src="https://i.gyazo.com/84a3fa6a2e20bc8f8592d0ef5e35d005.png" width="400"/></a></td>
    <td><a href="https://gyazo.com/305982e5b1f8b218bd020800f6bfee5a"><img src="https://i.gyazo.com/305982e5b1f8b218bd020800f6bfee5a.png" width="400"/></a></td>
  </tr>
</table>

完成予定ER図
[![完成予定ER図](https://i.gyazo.com/ce2c4d8559da6a471ba5e75ab73166d1.png)](https://dbdiagram.io/d/68f9ef31357668b7323f223e)

> [dbdiagram.io で詳細を見る](https://dbdiagram.io/d/68f9ef31357668b7323f223e)

👇該当コード直リンク
https://github.com/Yadon987/tekumemo/blob/main/db/schema.rb#L143-L174






---

## 📋 変更内容

`users` テーブルを以下の4テーブルに分割・正規化を行う。

1. **`users`** (認証・権限): Devise認証、権限管理のみに特化
2. **`accounts`** (外部連携): Google認証トークン・有効期限等の分離
3. **`user_settings`** (設定): 通知設定、目標距離などの分離
4. **`user_profiles`** (表示): ユーザー名、アバター情報の分離
5. **`重複カラム削除`**: `is_admin` は不要なため削除

---

## ✨ 期待される効果

- 🧠 **メモリ使用量の削減**: 認証時に巨大なトークンや不要な設定値をロードしない
- 🎯 **責務の明確化**: "Fat User Model" を解消し、機能ごとのクラス設計へ移行
- 📦 **データ容量の最適化**: 外部連携未使用ユーザーの無駄なレコード作成を防止

---

## 📝 補足

- 正規化に伴う管理用カラム（ID等）の追加により、物理カラム総数は増加（27→37）
- N+1問題への対策および既存機能との互換性を確保して実装を実施
- 既存データ（Google Fit連携等）への影響なし（互換性維持）

---

## 🔍 現状分析

### 現在の users テーブル構成 (27カラム)

| カテゴリ                     | カラム名                                                                                                    | 移動先                        |
| :--------------------------- | :---------------------------------------------------------------------------------------------------------- | :---------------------------- |
| 🔐 **認証コア (Devise必須)** | email, encrypted_password, reset_password_token, reset_password_sent_at, remember_created_at                | **users (残す)**              |
| 🛤 **Devise Trackable**      | sign_in_count, current_sign_in_at, last_sign_in_at, current_sign_in_ip, last_sign_in_ip                     | **users (残す)**              |
| 🛡 **権限**                  | role                                                                                                        | **users (残す)**              |
| 👤 **プロフィール**          | name, avatar_url, avatar_type                                                                               | 🚀 **user_profiles (新規)**   |
| 🔑 **Google OAuth**          | google_uid, google_token, google_refresh_token, google_expires_at                                           | 🚀 **accounts (新規)**        |
| ⚙️ **ユーザー設定**          | goal_meters, is_walk_reminder, walk_reminder, is_inactive_reminder, inactive_days, is_reaction_summary      | 🚀 **user_settings (新規)**   |
| 🕒 **タイムスタンプ**        | created_at, updated_at                                                                                      | **users (残す)**              |

---

## 🗑️ 不要カラムの調査

### `is_admin` ＆ `role` 調査結果

> **結論: `is_admin` は削除可能なレガシーカラム**

コード全体を徹底調査した結果、`is_admin` カラムは**一切使用されていない**ことが判明。

| 日付       | マイグレーション        | 内容                          |
| ---------- | ----------------------- | ----------------------------- |
| 2025/12/11 | `add_is_admin_to_users` | `is_admin` boolean カラム追加 |
| 2025/12/14 | `add_role_to_users`     | `role` integer カラム追加     |

**経緯**: 当初 `is_admin` booleanで管理者判定を実装したが、後に「ゲストユーザー」導入に伴い `role` enum（general, admin, guest）に移行。現在のコードは全て `role` enum（`admin?`, `guest?` メソッド）を使用。

---

## 🛡️ N+1問題への対策

`name` や `avatar_url` は `users` テーブルに残すことで回避。
分離するテーブルについては `includes` を適切に追加して対応。

---

## 📐 各テーブルの切り出しイメージ(※アコーディオンになってます)

<details>
<summary>🔑 accounts テーブル</summary>

```ruby
create_table :accounts do |t|
  t.references :user, null: false, foreign_key: true, index: { unique: true }
  t.string :google_uid, null: false
  t.text :google_token
  t.text :google_refresh_token
  t.datetime :google_expires_at
  t.timestamps
end
```

</details>

<details>
<summary>⚙️ user_settings テーブル</summary>

```ruby
create_table :user_settings do |t|
  t.references :user, null: false, foreign_key: true, index: { unique: true }
  t.integer :goal_meters, default: 3000, null: false
  t.boolean :is_walk_reminder, default: false, null: false
  t.time :walk_reminder, default: '19:00'
  t.boolean :is_inactive_reminder, default: true, null: false
  t.integer :inactive_days, default: 3, null: false
  t.boolean :is_reaction_summary, default: true, null: false
  t.timestamps
end
```

</details>

<details>
<summary>👤 user_profiles テーブル</summary>

```ruby
create_table :user_profiles do |t|
  t.references :user, null: false, foreign_key: true, index: { unique: true }
  t.string :name, null: false
  t.text :avatar_url
  t.integer :avatar_type, default: 0, null: false
  t.timestamps
end
```

</details>

<details>
<summary>🔐 users テーブル（最終形）</summary>

```ruby
create_table :users do |t|
  t.string :email, default: "", null: false
  t.string :encrypted_password, default: "", null: false
  t.string :reset_password_token
  t.datetime :reset_password_sent_at
  t.datetime :remember_created_at
  t.integer :sign_in_count, default: 0, null: false
  t.datetime :current_sign_in_at
  t.datetime :last_sign_in_at
  t.string :current_sign_in_ip
  t.string :last_sign_in_ip
  t.integer :role, default: 0, null: false  # 0:general, 1:admin, 2:guest
  t.datetime :created_at, null: false
  t.datetime :updated_at, null: false
  t.index ["email"], name: "index_users_on_email", unique: true
  t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
end
```

</details>
